### PR TITLE
Supply explicit column names for INSERT & SELECT

### DIFF
--- a/docs/_mssql_examples.rst
+++ b/docs/_mssql_examples.rst
@@ -13,13 +13,13 @@ Quickstart usage of various features
     conn = _mssql.connect(server='SQL01', user='user', password='password', \
         database='mydatabase')
     conn.execute_non_query('CREATE TABLE persons(id INT, name VARCHAR(100))')
-    conn.execute_non_query("INSERT INTO persons VALUES(1, 'John Doe')")
-    conn.execute_non_query("INSERT INTO persons VALUES(2, 'Jane Doe')")
+    conn.execute_non_query("INSERT INTO persons (id, name) VALUES(1, 'John Doe')")
+    conn.execute_non_query("INSERT INTO persons (id, name) VALUES(2, 'Jane Doe')")
 
 ::
 
     # how to fetch rows from a table
-    conn.execute_query('SELECT * FROM persons WHERE salesrep=%s', 'John Doe')
+    conn.execute_query('SELECT id, name FROM persons WHERE salesrep=%s', 'John Doe')
     for row in conn:
         print "ID=%d, Name=%s" % (row['id'], row['name'])
 


### PR DESCRIPTION
Poviding explicit columns names for INSERT and SELECT statement examples should promote best coding practices.  Such code is more resilient to schema changes and even some database restore/recovery procedures (which may fail to preserve column ordering even without any semantic schema changes).